### PR TITLE
Add set_stats task to populate Artifacts in Controller Job Run

### DIFF
--- a/project/create_rhel_vm_demo.yml
+++ b/project/create_rhel_vm_demo.yml
@@ -39,7 +39,7 @@
       set_stats:
         data: 
           azure_vm_public_ip: "{{ output_ip_address.state.ip_address }}"
-        data: false
+        per_host: false
       when: survey_public_ip == "True"
 
     - name: Create Network Security Group that allows SSH and RDP

--- a/project/create_rhel_vm_demo.yml
+++ b/project/create_rhel_vm_demo.yml
@@ -35,6 +35,13 @@
         msg: "The public IP is {{ output_ip_address.state.ip_address }}"
       when: survey_public_ip == "True"
 
+    - name: Set Stat for Ansible Controller
+      set_stats:
+        data: 
+          azure_vm_public_ip: "{{ output_ip_address.state.ip_address }}"
+        data: false
+      when: survey_public_ip == "True"
+
     - name: Create Network Security Group that allows SSH and RDP
       azure.azcollection.azure_rm_securitygroup:
         resource_group: "{{ resource_group_name }}"

--- a/project/create_windows_vm_demo.yml
+++ b/project/create_windows_vm_demo.yml
@@ -32,6 +32,12 @@
       debug:
         msg: "The public IP is {{ output_ip_address.state.ip_address }}"
 
+    - name: Set Stat for Ansible Controller
+      set_stats:
+        data: 
+          azure_vm_public_ip: "{{ output_ip_address.state.ip_address }}"
+        per_host: false
+
     - name: Create Network Security Group that allows SSH and RDP
       azure_rm_securitygroup:
         resource_group: "{{ resource_group_name }}"


### PR DESCRIPTION
This task adds a `set_stats` task to the RHEL and Windows Deployment.  When ran from Ansible Controller, the variable content will show up as artifacts on the job run. This makes it easier to find the IP address, and also include it in a larger workflow of job templates.