### PR TITLE
Destroy Peering Demo Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Once the playbook completes, you should be able to SSH into the public VM and ro
 The following are required extra-vars needed to run the playbook.  Similar to the previous examples, you should create an extra-vars file in the `env` folder to store them.  You may create a file with a separate name, like `env/extravars-peering` to maintain both sets of variables.
 
 ```yaml
+---
 # Required
 debug: false
 resource_group_name: rg-peering-demo

--- a/project/destroy_peer_network_demo.yml
+++ b/project/destroy_peer_network_demo.yml
@@ -47,11 +47,12 @@
       tags:
         - network
         - peering
-    - name: Create Resource Group
+    - name: Delete Resource Group
       azure.azcollection.azure_rm_resourcegroup:
         name: "{{ resource_group_name }}"
         location: "{{ region }}"
         state: absent
+        force_delete_nonempty: true
         tags:
           deployment: ansible
       tags:


### PR DESCRIPTION
- Ensures that the demo resource group can be deleted using the `force_delete_nonempty` flag
- Doc fixes